### PR TITLE
All "Hermits" can now drop a shiny nugget trophy

### DIFF
--- a/whitesands/code/modules/mob/living/simple_animal/hostile/whitesands/survivors.dm
+++ b/whitesands/code/modules/mob/living/simple_animal/hostile/whitesands/survivors.dm
@@ -42,7 +42,7 @@
 	del_on_death = 1
 	faction = list("hermit", "wasteland") // VOID edit
 
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor/death(gibbed)
+/mob/living/simple_animal/hostile/asteroid/whitesands/death(gibbed)
 	move_force = MOVE_FORCE_DEFAULT
 	move_resist = MOVE_RESIST_DEFAULT
 	pull_force = PULL_FORCE_DEFAULT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously, the melee hermit, known as the "Hermit Wanderer", could spawn on sand planets. Upon death from any source, they had a 15% chance to drop the shiny nugget crusher trophy, which increases the chance of trophies dropping in general. Apocalyptic planets spawn hermits, but only the ranged variants. Strangely, the random hermit spawner code only spawns the ranged variants, despite being a proc under the melee variant. The ranged variants aren't even subtypes of the melee variant. 

So, basically, all "Hermits" now have a 15% chance to drop a shiny nugget when killed by anything, rather than just the melee variant that doesn't spawn. I could have just made the melee variant spawn, but it seems like all variants were meant to drop the nugget to begin with anyway, and the melee variant is a bit underwhelming to fight.

![image](https://user-images.githubusercontent.com/44104681/208801756-b126d55d-97bd-47b7-bf9c-dff172a20a17.png)
![image](https://user-images.githubusercontent.com/44104681/208801765-ce063668-c1b5-469e-842f-de7c5e6c0bc3.png)
![image](https://user-images.githubusercontent.com/44104681/208801774-d6f9ca59-746b-4208-8921-6f42997bb34e.png)
![image](https://user-images.githubusercontent.com/44104681/208801791-f6fa13e2-98f7-4e7e-9941-07bc7d9ee730.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
(Seemingly) broken code is bad. The shiny nugget is a very nice piece of quality of life and it's very unfortunate to have lost it when sand planets were lost. Personally, I still want to see sand planets make a return. For now, though, this is just a really good reason to visit apocalyptic planets if you weren't doing it already.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Recently, expedition squads have found strange nuggets of a golden metal in the pockets of slain hermit soldiers and hunters. (The "shiny nugget" crusher trophy is no longer unobtainable.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
